### PR TITLE
Fix dialogue timeout management

### DIFF
--- a/gameLogic.js
+++ b/gameLogic.js
@@ -100,6 +100,7 @@ export function startDialogue(dialogueId) {
     updateEssence(-totalEssenceCost);
     updateDarkEssence(-totalDarkEssenceCost);
 
+    timeoutManager.clear('dialogueEnd');
     setActiveDialogue(dialogueDef);
     updateInteractionPanelHeight(); // Ustawiamy wysokość panelu
 
@@ -202,7 +203,7 @@ export function selectOption(dialogueId, optionId) {
         }
         clearActiveDialogue();
         ui.updateDisplay();
-    }, 6000);
+    }, 60000);
 }
 
 export function applyStageSpecificUnlocks() {


### PR DESCRIPTION
## Summary
- clear any existing dialogue timeout when starting a new conversation
- extend dialogue auto-close delay to one minute

## Testing
- `node --check gameLogic.js`


------
https://chatgpt.com/codex/tasks/task_e_6844ce62a8c4833299118a7933709106