### PR TITLE
Add check for completed temptations

### DIFF
--- a/gameLogic.js
+++ b/gameLogic.js
@@ -357,6 +357,8 @@ export function changeAssignedMinions(temptationId, amount) {
 export function startTemptation(temptationId, isApprenticeMission = false) {
     const temptationDef = gameDefinitions.temptationMissions.find(t => t.id === temptationId);
     if (!temptationDef) return;
+    const temptationState = gameState.temptationMissionsState.find(t => t.id === temptationId);
+    if (temptationState?.isCompleted && !temptationDef.isRepeatable) return;
 
     if (isApprenticeMission) {
         if (gameState.activeTemptationApprentice || gameState.activeTemptation === temptationId) return;

--- a/uiUpdates.js
+++ b/uiUpdates.js
@@ -557,7 +557,7 @@ function renderTemptations() {
             const lilithButton = document.createElement('button');
             lilithButton.classList.add('interactive-button', 'temptation-button-custom', 'mt-2');
             lilithButton.textContent = "Rozpocznij Pokusę (Lilith)";
-            if (gameState.essence < temptationDef.essenceCost || gameState.darkEssence < temptationDef.darkEssenceCost || gameState.activeTemptation) {
+            if (gameState.essence < temptationDef.essenceCost || gameState.darkEssence < temptationDef.darkEssenceCost || gameState.activeTemptation || (temptationState.isCompleted && !temptationDef.isRepeatable)) {
                 lilithButton.disabled = true;
             }
             lilithButton.onclick = () => import('./gameLogic.js').then(logic => logic.startTemptation(temptationDef.id, false));
@@ -566,7 +566,7 @@ function renderTemptations() {
                 const apprenticeButton = document.createElement('button');
                 apprenticeButton.classList.add('interactive-button', 'temptation-button-apprentice-custom', 'mt-1');
                 apprenticeButton.textContent = "Rozpocznij Pokusę (Uczennica)";
-                if (gameState.essence < temptationDef.essenceCost || gameState.darkEssence < temptationDef.darkEssenceCost) {
+                if (gameState.essence < temptationDef.essenceCost || gameState.darkEssence < temptationDef.darkEssenceCost || (temptationState.isCompleted && !temptationDef.isRepeatable)) {
                     apprenticeButton.disabled = true;
                 }
                 apprenticeButton.onclick = () => import('./gameLogic.js').then(logic => logic.startTemptation(temptationDef.id, true));


### PR DESCRIPTION
## Summary
- prevent starting already-completed non-repeatable temptations
- disable temptation buttons when the mission has been completed

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844cc3c0ebc8332aa4c49d5fc5d392a