### PR TITLE
Add config validation on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Game progress is stored in `localStorage` under the key `succubusCorruptionGameS
 - All `.js` files use ES module syntax.
 - Tailwind CSS is included from a CDN.
 - There is no build process.
+- `main.js` runs configuration validation on startup. If any upgrade,
+  research project or temptation is missing its config data you will see a
+  console warning and an alert in the browser.
 
 ## Known Limitations
 

--- a/main.js
+++ b/main.js
@@ -6,6 +6,20 @@ import { initGame, generateEssence, stopAllIntervals } from './gameLogic.js';
 import { showCustomAlert, hideCustomAlert, updateDisplay, clearAllUiTimeouts } from './uiUpdates.js';
 // NOWE: Import funkcji aktualizujących zasoby dla przycisków testowych
 import { updateEssence, updateDarkEssence, updateCorruption } from './stateUpdaters.js';
+// Import definicji i walidatorów konfiguracji
+import { upgrades, researchProjects, temptationMissions } from './gameSystems.js';
+import { validateUpgradeConfig, validateResearchConfig, validateTemptationConfig } from './gameConfig.js';
+
+// Validate configuration consistency
+const upgradesValid = validateUpgradeConfig(upgrades.map(u => u.id));
+const researchValid = validateResearchConfig(researchProjects.map(rp => rp.id));
+const temptationsValid = validateTemptationConfig(temptationMissions.map(t => t.id));
+if (!upgradesValid || !researchValid || !temptationsValid) {
+    console.warn('Detected configuration issues with game data.');
+    if (typeof showCustomAlert === 'function') {
+        showCustomAlert('Wykryto problemy z konfiguracją. Sprawdź konsolę.');
+    }
+}
 
 // =======================================================
 // NOWA FUNKCJA DO REGULACJI WYSOKOŚCI PANELU


### PR DESCRIPTION
## Summary
- run configuration validation when `main.js` loads
- warn and show an alert if any config entry is missing
- document the validation step in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684502b192b083328a05c7d2437b2939