### PR TITLE
Disable corruption gating

### DIFF
--- a/gameLogic.js
+++ b/gameLogic.js
@@ -212,7 +212,7 @@ export function applyStageSpecificUnlocks() {
         if (upgState && !upgState.unlocked && !upgState.purchased) {
             let shouldUnlock = false;
             if (upgDef.requiredStage !== undefined && gameState.lilithStage >= upgDef.requiredStage) shouldUnlock = true;
-            if (upgDef.corruptionRequired !== undefined && gameState.corruption >= upgDef.corruptionRequired) shouldUnlock = true;
+            // Temporarily ignore corruption requirements during early balancing
             if (upgDef.initialUnlockedState) shouldUnlock = true;
             if (shouldUnlock) setUpgradeUnlocked(upgDef.id, true);
         }
@@ -237,7 +237,7 @@ export function checkAndUnlockDiaryEntries() {
         const conditions = entry.unlockConditions;
         let canUnlock = true;
         if (conditions.stageRequired !== undefined && gameState.lilithStage < conditions.stageRequired) canUnlock = false;
-        if (conditions.corruptionMin !== undefined && gameState.corruption < conditions.corruptionMin) canUnlock = false;
+        // Corruption requirements are currently disabled
         if (conditions.completedDialogueId && !gameState.completedDialogues.includes(conditions.completedDialogueId)) canUnlock = false;
         if (conditions.choiceMadeInDialogue) {
             const flagToCheck = `choice_${conditions.choiceMadeInDialogue.dialogueId}_${conditions.choiceMadeInDialogue.optionId}`;

--- a/gameSystems.js
+++ b/gameSystems.js
@@ -91,10 +91,7 @@ export function isGameAreaUnlocked(areaId, gameState) {
         return false;
     }
 
-    // Check corruption requirement (if defined)
-    if (unlockConditions.requiredCorruption !== undefined && gameState.corruption < unlockConditions.requiredCorruption) {
-        return false;
-    }
+    // Corruption requirements are disabled for now
 
     // Check required flags
     if (unlockConditions.requiredFlags) {

--- a/ui/dialogues.js
+++ b/ui/dialogues.js
@@ -39,7 +39,7 @@ function renderAvailableDialogues() {
         }
         return;
     }
-    dialogues.filter(d => (d.isBreakingPoint || d.id === 'vocal_breakthrough_dialogue') && !gameState.completedDialogues.includes(d.id) && gameState.lilithStage >= d.stageRequired && gameState.corruption >= (d.corruptionRequired || 0) && (!d.condition || d.condition(gameState))).forEach(dialogue => {
+    dialogues.filter(d => (d.isBreakingPoint || d.id === 'vocal_breakthrough_dialogue') && !gameState.completedDialogues.includes(d.id) && gameState.lilithStage >= d.stageRequired && (!d.condition || d.condition(gameState))).forEach(dialogue => {
         const button = document.createElement('button');
         button.classList.add('interactive-button', 'button-accent', 'border-2', 'border-yellow-400', 'pulse-animation');
         if (dialogue.imagePath) {

--- a/ui/upgrades.js
+++ b/ui/upgrades.js
@@ -14,7 +14,7 @@ function renderUpgrades() {
         if (upgradeDef.id === 'recruit_arch_succubus_apprentice' && (!gameState.playerChoiceFlags.includes('lilith_is_arch_succubus') || gameState.eliteMinion.apprentice.recruited)) return;
         if (!upgradeState.unlocked || (upgradeState.purchased && !isChoiceUnlockPending && upgradeDef.id !== 'train_praktykant_1' && upgradeDef.id !== 'recruit_arch_succubus_apprentice')) return;
         if (upgradeDef.requiredStage && gameState.lilithStage < upgradeDef.requiredStage) return;
-        if (upgradeDef.corruptionRequired && gameState.corruption < upgradeDef.corruptionRequired) return;
+        // Temporarily ignore corruption gating on upgrades
         const tooltipContainer = document.createElement('div');
         tooltipContainer.classList.add('tooltip-container');
         const button = document.createElement('button');
@@ -93,7 +93,7 @@ function renderDarkRituals() {
     dom.darkRitualsListEl.innerHTML = '';
     allDarkRituals.forEach(ritualDef => {
         const ritualState = gameState.darkRitualsState.find(s => s.id === ritualDef.id);
-        if (!ritualState || ritualState.isCompleted || gameState.lilithStage < ritualDef.requiredStage || (ritualDef.corruptionRequired && gameState.corruption < ritualDef.corruptionRequired)) return;
+        if (!ritualState || ritualState.isCompleted || gameState.lilithStage < ritualDef.requiredStage) return;
         if (ritualDef.id === 'ritual_arch_succubus_ascension' && gameState.playerChoiceFlags.includes('lilith_is_arch_succubus')) return;
         const ritualDiv = document.createElement('div');
         ritualDiv.classList.add('ritual-item', 'mb-3', 'p-3', 'border', 'rounded-md');
@@ -158,7 +158,7 @@ function renderTemptations() {
     } else {
         allTemptationMissions.forEach(temptationDef => {
             const temptationState = gameState.temptationMissionsState.find(ts => ts.id === temptationDef.id) || { assignedMinions: 0, isCompleted: false };
-            if ((temptationState.isCompleted && !temptationDef.isRepeatable) || gameState.lilithStage < temptationDef.requiredLilithStage || gameState.corruption < temptationDef.requiredCorruption) return;
+            if ((temptationState.isCompleted && !temptationDef.isRepeatable) || gameState.lilithStage < temptationDef.requiredLilithStage) return;
             const temptationDiv = document.createElement('div');
             temptationDiv.classList.add('temptation-item-custom', 'mb-3', 'p-4', 'rounded-lg', 'shadow-md');
             const nameEl = document.createElement('h4');

--- a/uiUpdates.js
+++ b/uiUpdates.js
@@ -138,7 +138,7 @@ export function displayLilithThought() {
 
     const possibleThoughts = currentStageThoughts.filter(thought => {
         const stageMatch = thought.stageRequired !== undefined ? gameState.lilithStage >= thought.stageRequired : true;
-        const corruptionMatch = thought.corruption ? (gameState.corruption >= thought.corruption[0] && gameState.corruption <= thought.corruption[1]) : true;
+        const corruptionMatch = true; // ignore corruption gating for now
         let flagMatch = thought.requiresFlag ? gameState.playerChoiceFlags.includes(thought.requiresFlag) : true;
         if (thought.requiresFlagSecondary && flagMatch) {
             flagMatch = gameState.playerChoiceFlags.includes(thought.requiresFlagSecondary);
@@ -195,8 +195,7 @@ export function displayRandomVocalThought() {
     const possibleThoughts = lilithVocalThoughts.filter(thought => {
         if (thought.id === 'initial_vocal_thought') return false;
         if (thought.stageRequired && gameState.lilithStage < thought.stageRequired) return false;
-        if (thought.corruptionMin && gameState.corruption < thought.corruptionMin) return false;
-        if (thought.corruptionMax && gameState.corruption > thought.corruptionMax) return false;
+        // Corruption-based filters are disabled
         if (thought.requiresFlag && !thought.requiresFlag.every(flag => gameState.playerChoiceFlags.includes(flag))) return false;
         if (thought.requiresNoFlag && thought.requiresNoFlag.some(flag => gameState.playerChoiceFlags.includes(flag))) return false;
         if (thought.sexualPreference) {


### PR DESCRIPTION
## Summary
- ignore corruption gating for upgrades, diaries, game areas, and thoughts
- allow late game dialogues and actions without corruption checks

## Testing
- `npm run test`
- `npm run lint` *(fails: config error)*

------
https://chatgpt.com/codex/tasks/task_e_68451d97d2cc8332978a8d7f6546a19f