### PR TITLE
Introduce critical click system

### DIFF
--- a/data/upgrades.js
+++ b/data/upgrades.js
@@ -1,4 +1,4 @@
-import { setNestUpgrade, updateCorruption, updateDarkEssence, increasePassiveDarkEssencePerSecond, setCorruptionBonusMultiplier, addPlayerChoiceFlag, setEliteMinionRecruited, setEliteMinionLevel, setMinionUnlocked, increaseMinionCount } from "../stateUpdaters.js";
+import { setNestUpgrade, updateCorruption, updateDarkEssence, increasePassiveDarkEssencePerSecond, setCorruptionBonusMultiplier, addPlayerChoiceFlag, setEliteMinionRecruited, setEliteMinionLevel, setMinionUnlocked, increaseMinionCount, setActionModifier } from "../stateUpdaters.js";
 import { UPGRADE_COSTS, UPGRADE_VALUES, NEST_UPGRADE_REWARDS } from "../gameConfig.js";
 
 export const upgrades = [
@@ -90,6 +90,19 @@ export const upgrades = [
         type: 'choice_unlock',
         unlocksChoiceGroupId: 'essence_mastery_1',
         purchased: false, unlocked: false, initialUnlockedState: false, requiredStage: 2
+    },
+    {
+        id: 'critical_click_training',
+        name: 'Sekret Demonicznego Dotyku',
+        cost: UPGRADE_COSTS.critical_click_training.essence,
+        darkEssenceCost: UPGRADE_COSTS.critical_click_training.darkEssence || undefined,
+        description: 'Lilith zdradza Ci technikę skupiania energii w jednym punkcie. Kliknięcia mają 20% szansy dać potrójną ilość Esencji.',
+        type: 'special',
+        onPurchase: (gs) => { setActionModifier('criticalChance', UPGRADE_VALUES.critical_click_chance); setActionModifier('criticalMultiplier', UPGRADE_VALUES.critical_click_multiplier); },
+        purchased: false,
+        unlocked: false,
+        initialUnlockedState: false,
+        requiredStage: 2
     },
     {
         id: 'nest_bed_upgrade_1',

--- a/gameConfig.js
+++ b/gameConfig.js
@@ -12,6 +12,7 @@ export const UPGRADE_COSTS = {
     essence_boost_2: { essence: 300, darkEssence: 0 },
     passive_essence_2: { essence: 1200, darkEssence: 0 },
     essence_mastery_choice_unlock: { essence: 400, darkEssence: 0 },
+    critical_click_training: { essence: 500, darkEssence: 20 },
     
     // Nest Upgrades
     nest_bed_upgrade_1: { essence: 200, darkEssence: 10 },
@@ -40,6 +41,8 @@ export const UPGRADE_VALUES = {
     
     // Action Modifiers
     purity_chance_1: 0.1,
+    critical_click_chance: 0.2,
+    critical_click_multiplier: 2,
     
     // Dark Essence Multipliers
     dark_gift_shadow_kiss: 0.10,

--- a/gameLogic.js
+++ b/gameLogic.js
@@ -80,9 +80,17 @@ export function stopAllIntervals() {
     }
 }
 
+
 export function generateEssence() {
     if (!gameState.essenceGenerationUnlocked) return;
-    updateEssence(gameState.essencePerClick);
+    let gain = gameState.essencePerClick;
+    let critical = false;
+    if (gameState.actionModifiers.criticalChance > 0 && Math.random() < gameState.actionModifiers.criticalChance) {
+        gain *= gameState.actionModifiers.criticalMultiplier || 2;
+        critical = true;
+    }
+    updateEssence(gain);
+    if (critical) ui.playCriticalClickEffect();
     if (gameState.actionModifiers.purityChance > 0 && Math.random() < gameState.actionModifiers.purityChance) {
         updateDarkEssence(Math.floor(1 * gameState.darkEssenceMultiplier));
     }
@@ -90,8 +98,8 @@ export function generateEssence() {
     applyStageSpecificUnlocks();
     ui.markResourcesDirty();
     ui.updateDisplay();
-}
 
+}
 export function startDialogue(dialogueId) {
     const dialogueDef = gameDefinitions.dialogues.find(item => item.id === dialogueId);
     if (!dialogueDef) return;

--- a/playerState.js
+++ b/playerState.js
@@ -56,7 +56,7 @@ function getDefaultGameState() {
         completedDialogues: [],
         playerChoiceFlags: [],
         unlockedDiaryEntryIds: [],
-        actionModifiers: { purityChance: 0 },
+        actionModifiers: { purityChance: 0, criticalChance: 0, criticalMultiplier: 1 },
         activeDialogue: null,
         lastEssenceReactionThreshold: 0,
         lastThoughtTimestamp: 0,

--- a/style.css
+++ b/style.css
@@ -89,7 +89,7 @@ h1, h2, h3, h4, h5, h6 {
     box-shadow: 0 1px 3px 0 rgba(0,0,0,0.1), 0 1px 2px 0 rgba(0,0,0,0.06); text-align: center;
 }
 .resource-item-custom .emoji { font-size: 1.5rem; display: block; margin-bottom: 0.25rem; }
-.lilith-image-placeholder { background-color: rgb(var(--color-surface-dark)); }
+.lilith-image-placeholder { background-color: rgb(var(--color-surface-dark)); position: relative; overflow: hidden; }
 .lilith-feedback p { font-size: 0.875rem; font-style: italic; transition: opacity 0.5s ease-in-out; margin-top: 0.25rem; }
 #lilith-essence-reaction { color: rgb(var(--color-primary-light)); }
 #lilith-upgrade-reaction { color: rgb(var(--color-success)); }
@@ -286,4 +286,22 @@ h1, h2, h3, h4, h5, h6 {
     object-fit: cover;
     display: block;
     margin-bottom: 4px;
+}
+@keyframes critical-spark {
+    from { opacity: 1; transform: scale(0); }
+    to { opacity: 0; transform: scale(2); }
+}
+
+.critical-spark {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 80px;
+    height: 80px;
+    margin-top: -40px;
+    margin-left: -40px;
+    pointer-events: none;
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(var(--color-accent),1) 0%, rgba(var(--color-accent),0) 70%);
+    animation: critical-spark 0.6s ease-out forwards;
 }

--- a/uiUpdates.js
+++ b/uiUpdates.js
@@ -105,6 +105,14 @@ export function hideCustomAlert() {
     if (dom.customAlertModalEl) dom.customAlertModalEl.classList.add('hidden');
 }
 
+export function playCriticalClickEffect() {
+    if (!dom.lilithImageContainerEl) return;
+    const spark = document.createElement('div');
+    spark.className = 'critical-spark';
+    dom.lilithImageContainerEl.appendChild(spark);
+
+    setTimeout(() => spark.remove(), 600);
+}
 export function displayEssenceReaction() {
     for (const reaction of essenceReactions) {
         if (gameState.essence >= reaction.threshold && gameState.lastEssenceReactionThreshold < reaction.threshold) {


### PR DESCRIPTION
## Summary
- add new upgrade `critical_click_training`
- support critical click chance and multiplier in config and state
- implement critical click effect with new UI animation
- adjust generateEssence to use critical clicks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68454752c51c833289787d8457c5f95f