### PR TITLE
Display passive dark essence rate

### DIFF
--- a/domElements.js
+++ b/domElements.js
@@ -4,6 +4,7 @@
 export const essenceCountEl = document.getElementById('essence-count');
 export const darkEssenceCountEl = document.getElementById('dark-essence-count');
 export const passiveEssenceRateEl = document.getElementById('passive-essence-rate');
+export const passiveDarkEssenceRateEl = document.getElementById('passive-dark-essence-rate');
 export const corruptionCountEl = document.getElementById('corruption-count');
 export const essencePerClickEl = document.getElementById('essence-per-click');
 

--- a/index.html
+++ b/index.html
@@ -36,6 +36,9 @@
                         <div class="resource-item-custom">
                             <span class="emoji">⏱️</span><div class="text-sm" style="color: rgb(var(--color-primary-light)); opacity: 0.8;">Esencja/sek</div><strong id="passive-essence-rate" class="text-xl block">0.0</strong>
                         </div>
+                        <div class="resource-item-custom">
+                            <span class="emoji">🌑</span><div class="text-sm" style="color: rgb(var(--color-dark-essence)); opacity: 0.8;">Mroczna Esencja/sek</div><strong id="passive-dark-essence-rate" class="text-xl block">0.0</strong>
+                        </div>
                          <div class="resource-item-custom">
                             <span class="emoji">💗</span><div class="text-sm" style="color: rgb(var(--color-corruption));">Korupcja</div><strong id="corruption-count" class="text-xl block">0</strong>
                         </div>

--- a/uiUpdates.js
+++ b/uiUpdates.js
@@ -16,7 +16,7 @@ const MAX_RECENT_VOCAL_THOUGHTS = BALANCE_MODIFIERS.vocalThoughts.maxRecentThoug
 const VOCAL_THOUGHT_FADE_DURATION = BALANCE_MODIFIERS.vocalThoughts.fadeDelayMs;
 
 let uiStateCache = {
-    essence: null, darkEssence: null, passiveEssenceRate: null,
+    essence: null, darkEssence: null, passiveEssenceRate: null, passiveDarkEssenceRate: null,
     corruption: null, essencePerClick: null, lilithNameStage: null,
     lilithImageSrc: null, lilithImageAlt: null, lilithDescription: null,
     lilithVocalThought: null, essenceGenerationUnlocked: null,
@@ -251,6 +251,11 @@ function updateResourceDisplay() {
          currentPassiveEssence += eliteMinions.arch_succubus_apprentice.passiveEssenceGeneration;
     }
     updateTextContentIfNeeded(dom.passiveEssenceRateEl, currentPassiveEssence.toFixed(1), 'passiveEssenceRate');
+    let currentPassiveDarkEssence = gameState.passiveDarkEssencePerSecond;
+    if (gameState.eliteMinion.apprentice.recruited && eliteMinions.arch_succubus_apprentice?.passiveDarkEssenceGeneration) {
+         currentPassiveDarkEssence += eliteMinions.arch_succubus_apprentice.passiveDarkEssenceGeneration;
+    }
+    updateTextContentIfNeeded(dom.passiveDarkEssenceRateEl, currentPassiveDarkEssence.toFixed(1), 'passiveDarkEssenceRate');
     updateTextContentIfNeeded(dom.corruptionCountEl, gameState.corruption.toString(), 'corruption');
     updateTextContentIfNeeded(dom.essencePerClickEl, gameState.essencePerClick.toString(), 'essencePerClick');
 }


### PR DESCRIPTION
## Summary
- add display for passive dark essence gain
- expose `passiveDarkEssenceRateEl` in `domElements.js`
- compute passive dark essence rate in UI updates

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6845df9383d483328bf548fb3a7e26d7