### PR TITLE
Add idle event validation

### DIFF
--- a/scripts/validateGameData.js
+++ b/scripts/validateGameData.js
@@ -1,4 +1,16 @@
+import { idleEvents } from '../data/idleEvents.js';
 import { UPGRADE_COSTS, RESEARCH_COSTS, RESEARCH_REWARDS, TEMPTATION_COSTS, TEMPTATION_REWARDS, TEMPTATION_SUCCESS_RATES, validateUpgradeConfig, validateResearchConfig, validateTemptationConfig } from '../gameConfig.js';
+
+export function validateIdleEvents(upgradeIds) {
+    let valid = true;
+    for (const event of idleEvents) {
+        if (event.requiredUpgradeId && !upgradeIds.includes(event.requiredUpgradeId)) {
+            console.warn(`Idle event ${event.id} references missing upgrade: ${event.requiredUpgradeId}`);
+            valid = false;
+        }
+    }
+    return valid;
+}
 
 export function validateAll() {
     const upgradeIds = Object.keys(UPGRADE_COSTS);
@@ -7,7 +19,8 @@ export function validateAll() {
     const upgradesValid = validateUpgradeConfig(upgradeIds);
     const researchValid = validateResearchConfig(researchIds);
     const temptationsValid = validateTemptationConfig(temptationIds);
-    return upgradesValid && researchValid && temptationsValid;
+    const idleValid = validateIdleEvents(upgradeIds);
+    return upgradesValid && researchValid && temptationsValid && idleValid;
 }
 
 if (import.meta.main) {

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -1,7 +1,23 @@
 import assert from 'node:assert';
 import { validateAll } from '../scripts/validateGameData.js';
+import { idleEvents } from '../data/idleEvents.js';
 
-const result = validateAll();
+let result = validateAll();
 assert.ok(result, 'Game data validation failed');
+
+idleEvents.push({
+    id: 'invalid_test_event',
+    stageRequired: 1,
+    text: 'Invalid event',
+    requiredUpgradeId: 'non_existent_upgrade'
+});
+
+result = validateAll();
+assert.ok(!result, 'Validation should fail for idle events referencing missing upgrades');
+
+idleEvents.pop();
+result = validateAll();
+assert.ok(result, 'Game data validation failed after cleanup');
+
 console.log('All tests passed');
 


### PR DESCRIPTION
## Summary
- validate idle events and return `false` for missing upgrades
- add negative test case for idle event validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845df9fd5d8833297164be45d9ad085